### PR TITLE
Support OTP 24 and later

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -31,7 +31,6 @@
   {warnings,
    [
     error_handling,
-    race_conditions,
     unmatched_returns,
     unknown,
     no_improper_lists

--- a/rebar.config
+++ b/rebar.config
@@ -40,7 +40,7 @@
 
 {deps,
   [
-   {logi, ".*", {git, "git://github.com/sile/logi.git", {tag, "0.5.6"}}}
+   {logi, ".*", {git, "http://github.com/sile/logi.git", {tag, "0.5.7"}}}
   ]}.
 
 {profiles,

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,4 +1,4 @@
 [{<<"logi">>,
-  {git,"git://github.com/sile/logi.git",
-       {ref,"1022fbc238a7d18765fe864a7174958142160ee8"}},
+  {git,"http://github.com/sile/logi.git",
+       {ref,"38b39797553a977a4cf72dca67149ef469d97a6c"}},
   0}].

--- a/test/gen_cop_tests.erl
+++ b/test/gen_cop_tests.erl
@@ -8,19 +8,21 @@
 %%----------------------------------------------------------------------------------------------------------------------
 -define(assertDown(Pid, ExpectedReason),
         (fun () ->
-                 __Monitor = monitor(process, Pid),
+                 GEN_COP_TEST__Monitor = monitor(process, Pid),
                  receive
-                     {'DOWN', __Monitor, _, _, __Reason} -> ?assertMatch(ExpectedReason, __Reason)
+                     {'DOWN', GEN_COP_TEST__Monitor, _, _, GEN_COP_TEST__Reason} ->
+                         ?assertMatch(ExpectedReason, GEN_COP_TEST__Reason)
                  after 500 -> ?assert(timeout)
                  end
          end)()).
 
 -define(assertDown(Pid, ExitReason, ExpectedReason),
         (fun () ->
-                 __Monitor = monitor(process, Pid),
+                 GEN_COP_TEST__Monitor = monitor(process, Pid),
                  _ = exit(Pid, ExitReason),
                  receive
-                     {'DOWN', __Monitor, _, _, __Reason} -> ?assertMatch(ExpectedReason, __Reason)
+                     {'DOWN', GEN_COP_TEST__Monitor, _, _, GEN_COP_TEST__Reason} ->
+                         ?assertMatch(ExpectedReason, GEN_COP_TEST__Reason)
                  after 500 -> ?assert(timeout)
                  end
          end)()).
@@ -28,7 +30,8 @@
 -define(assertAbort(Pid, ExpectedReason),
         (fun () ->
                  receive
-                     {'EXIT', Pid, __Reason} -> ?assertMatch(ExpectedReason, __Reason)
+                     {'EXIT', Pid, GEN_COP_TEST__Reason} ->
+                         ?assertMatch(ExpectedReason, GEN_COP_TEST__Reason)
                  after 500 -> ?assert(timeout)
                  end
          end)()).


### PR DESCRIPTION
This PR addresses the following problems to support newer OTP versions.

- logi needs update (with replacing old git:// URL)
- variables that starts with "__" cause unnecessary warnings that says they are already bound from OTP 24. (*1)
- dialyzer's race_conditions option was removed at OTP 25.

*1: example of unnecessary alread-bound warning
```
$ cat bound.erl && echo '-----' && erlc bound.erl
-module(bound).

-export([normal/0, underscore/0]).

normal() ->
    A = 1,
    A = 1,
    ok.

underscore() ->
    __A = 1,
    __A = 1,
    ok.
-----
bound.erl:12:5: Warning: variable '__A' is already bound. If you mean to ignore this value, use '_' or a different underscore-prefixed name
%   12|     __A = 1,
%     |     ^
```